### PR TITLE
Update books put with hateoas links

### DIFF
--- a/app.py
+++ b/app.py
@@ -173,9 +173,7 @@ def update_book(book_id):
                 }
             # Copy book
             book_copy = copy.deepcopy(book)
-            break # Exit the loop once the book is found and updated
-    if book_copy:
-        return jsonify(book_copy), 200
+            return jsonify(book_copy), 200
 
     return jsonify({"error": "Book not found"}), 404
 

--- a/app.py
+++ b/app.py
@@ -165,7 +165,7 @@ def update_book(book_id):
             book["author"] = request.json.get("author")
 
             # Ensure links exists as paths only
-            if "links" not in books:
+            if "links" not in book:
                 book["links"] = {
                     "self": f"/books/{book_id}",
                     "reservations": f"/books/{book_id}/reservations",

--- a/test_app.py
+++ b/test_app.py
@@ -353,7 +353,7 @@ def test_update_book_request_returns_required_fields(client):
         response_data = response.get_json()
 
         # Check that required fields are in the response data
-        required_fields = ["title", "synopsis", "author"]
+        required_fields = ["title", "synopsis", "author", "links"]
         for field in required_fields:
             assert field in response_data, f"{field} not in response_data"
 

--- a/test_app.py
+++ b/test_app.py
@@ -417,3 +417,33 @@ def test_update_book_sent_with_missing_required_fields(client):
     response_data = response.get_json()
     assert 'error' in response_data
     assert "Missing required fields: title, synopsis" in response.get_json()["error"]
+
+def test_update_book_adds_links_if_missing(client):
+     # Prepare a book without the 'links' field
+    book_without_links = {
+        "id": "1",
+        "title": "Original Title",
+        "author": "Original Author",
+        "synopsis": "Original Synopsis"
+    }
+    # Patch the books list with just this book (no links)
+    with patch("app.books", [book_without_links]):
+        updated_data = {
+            "title": "Updated Title",
+            "author": "Updated Author",
+            "synopsis": "Updated Synopsis"
+        }
+
+        response = client.put("/books/1", json=updated_data)
+        assert response.status_code == 200
+
+        data = response.get_json()
+        assert "links" in data
+        assert data["links"]["self"] == "/books/1"
+        assert data["links"]["reservations"] == "/books/1/reservations"
+        assert data["links"]["reviews"] == "/books/1/reviews"
+
+        # Verify other fields were updated
+        assert data["title"] == "Updated Title"
+        assert data["author"] == "Updated Author"
+        assert data["synopsis"] == "Updated Synopsis"

--- a/test_app.py
+++ b/test_app.py
@@ -447,3 +447,14 @@ def test_update_book_adds_links_if_missing(client):
         assert data["title"] == "Updated Title"
         assert data["author"] == "Updated Author"
         assert data["synopsis"] == "Updated Synopsis"
+
+def test_update_book_sent_with_invalid_book_id(client):
+    with patch("app.books", books_database):
+        test_book = {
+            "title": "Some title",
+            "author": "Some author",
+            "synopsis": "Some synopsis"
+        }
+        response = client.put("/books/999", json =test_book)
+        assert response.status_code == 404
+        assert "Book not found" in response.get_json()["error"]


### PR DESCRIPTION
## Description

Update the PUT /books/{id} endpoint as per Trello ticket https://trello.com/c/zyOKNTqV.
The ticket requires using the new ticket-specific append-host function to ensure the PUT handler stores only path segments in the links object.
Previously, the PUT endpoint didn’t add or update HATEOAS links because they were considered static.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Red, green, refactor, TDD approach, cURL requests and pylint/pytest + coverage

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **My individual commit messages are descriptive and follow our [commit guidelines](https://martijnhols.nl/blog/how-to-write-a-good-git-commit-message/)**
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

